### PR TITLE
Ci/check linted files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
         python-version: ${{ env.DEFAULT_PYTHON }}
     - name: Install dependencies
       run: pip install -r requirements.txt -r requirements-dev.txt
-    - name: Lint with pylint
-      run: pylint ./**/*.py
+    - name: Lint with pylint and shellcheck using script
+      run: ./dev/lint.sh
 
   test:
     if: ${{ github.ref_name == 'master' || github.event_name == 'pull_request' }}

--- a/check.sh
+++ b/check.sh
@@ -1,8 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -e
 
 pytest
 tests/cli.sh
-
-python "$(which pylint)" ./**/*.py
-shellcheck yt-queue ./**/*.sh
+dev/lint.sh

--- a/dev/lint.sh
+++ b/dev/lint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+mapfile -t py < <(git ls-files '*.py')
+echo "py files:" "${py[@]}"
+python "$(which pylint)" "${py[@]}"
+
+mapfile -t sh < <(git ls-files 'yt-queue' '*.sh')
+echo "sh files:" "${sh[@]}"
+shellcheck "${sh[@]}"


### PR DESCRIPTION
use `git ls-files` to find files, use `bash`;s mapfile to read lines
into array and pass that into pylint

print the names of the files

do the same for `sh`ell files

this is done t obe more sure that all files are actually linted (and not
missed by a glob)

[use the dev script to lint](https://github.com/pretorh/yt-queue/commit/1ad867c8725b41fffd701284b43f0b12719eb129)