### PR TITLE
Feat: add loggers and be less verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+### Added
+
+- Add loggers to control output
+
 ### Changed
 
 - Less verbose output in CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Less verbose output in CLI
+- Less verbose `yt_dlp` output
 
 ## 0.1.1
 

--- a/yt_queue/__init__.py
+++ b/yt_queue/__init__.py
@@ -1,6 +1,7 @@
 import sys
 from . import file
 from .internal import mapper, yt_dlp_wrapper
+from .utils.loggers import StdLogger
 
 VERSION = '0.1.1'
 _fullname = f"yt-queue {VERSION}"
@@ -15,27 +16,28 @@ def write(filename, playlist_data):
 
 # cli
 
+_log = StdLogger()
+
 def _create():
     info = sys.argv[2]
     url = sys.argv[3]
     create(info, url)
 
-def create(info, url):
-
+def create(info, url, logger=_log):
     data = {
         'url': url,
     }
     write(info, data)
-    print(f'{info} created')
+    logger.info(f'{info} created')
 
 def _refresh():
     info = sys.argv[2]
     refresh(info)
 
-def refresh(info):
+def refresh(info, logger=_log):
     data = read(info)
     url = data['url']
-    print(f'Refreshing {info} ({url})')
+    logger.info(f'Refreshing {info} ({url})')
     yt_info = yt_dlp_wrapper.extract_info(url)
 
     for entry in yt_info['entries']:
@@ -47,25 +49,27 @@ def _get_no_status():
     info = sys.argv[2]
     get_no_status(info)
 
-def get_no_status(info):
+def get_no_status(info, logger=_log):
+    _log.formatted_output = True
     data = read(info)
 
     found = [video for video in data['videos'] if 'status' not in video]
-    print(f'Found {len(found)} videos with no status in {info}', file=sys.stderr)
+    logger.info(f'Found {len(found)} videos with no status in {info}')
     for video in found:
-        print(video['id'])
+        logger.output(video['id'])
 
 def _get_status():
     [info, status] = sys.argv[2:4]
     get_status(info, status)
 
-def get_status(info, status):
+def get_status(info, status, logger=_log):
+    _log.formatted_output = True
     data = read(info)
 
     found = [video for video in data['videos'] if 'status' in video and video['status'] == status]
-    print(f'Found {len(found)} videos with status {status} in {info}', file=sys.stderr)
+    logger.info(f'Found {len(found)} videos with status {status} in {info}')
     for video in found:
-        print(video['id'])
+        logger.output(video['id'])
 
 def _set_status():
     [info, video_id, new_status] = sys.argv[2:5]
@@ -83,16 +87,17 @@ def _read_field():
     [info, video_id, field] = sys.argv[2:5]
     read_field(info, video_id, field)
 
-def read_field(info, video_id, field):
+def read_field(info, video_id, field, logger=_log):
+    _log.formatted_output = True
     data = read(info)
 
     found = [video for video in data['videos'] if video['id'] == video_id]
     if any(found) and field in found[0]:
-        print(found[0][field])
+        logger.output(found[0][field])
 
 def cli():
     if len(sys.argv) == 2 and sys.argv[1] == 'version':
-        print(_fullname)
+        _log.output(_fullname)
     elif len(sys.argv) == 4 and sys.argv[1] == 'create':
         _create()
     elif len(sys.argv) == 3 and sys.argv[1] == 'refresh':
@@ -106,6 +111,6 @@ def cli():
     elif len(sys.argv) == 5 and sys.argv[1] == 'read-field':
         _read_field()
     else:
-        print(_fullname)
-        print(f'unknown cli arguments {sys.argv}', file=sys.stderr)
+        _log.info(_fullname)
+        _log.warning(f'unknown cli arguments {sys.argv}')
         sys.exit(1)

--- a/yt_queue/__init__.py
+++ b/yt_queue/__init__.py
@@ -38,7 +38,7 @@ def refresh(info, logger=_log):
     data = read(info)
     url = data['url']
     logger.info(f'Refreshing {info} ({url})')
-    yt_info = yt_dlp_wrapper.extract_info(url)
+    yt_info = yt_dlp_wrapper.extract_info(url, yt_dlp_wrapper.ProgressLogger(logger))
 
     for entry in yt_info['entries']:
         mapper.map_and_merge(entry, data['videos'])

--- a/yt_queue/internal/yt_dlp_wrapper.py
+++ b/yt_queue/internal/yt_dlp_wrapper.py
@@ -1,8 +1,35 @@
 import yt_dlp
 
-def extract_info(url):
-    opts = { 'extract_flat': 'in_playlist' }
+def extract_info(url, yt_dlp_logger):
+    opts = {
+        'extract_flat': 'in_playlist',
+        'logger': yt_dlp_logger,
+    }
     with yt_dlp.YoutubeDL(opts) as ydl:
         yt_info = ydl.extract_info(url)
         yt_info = ydl.sanitize_info(yt_info)
     return yt_info
+
+class Logger:
+    def __init__(self, logger):
+        self.logger = logger
+
+    def debug(self, msg):
+        if msg.startswith('[debug] '):
+            pass
+        else:
+            self.info(msg)
+
+    def info(self, msg):
+        self.logger.info(f"yt_dlp: {msg}")
+
+    def warning(self, msg):
+        self.logger.warning(f"yt_dlp warning: {msg}")
+
+    def error(self, msg):
+        self.logger.error(f"yt_dlp error: {msg}")
+
+class ProgressLogger(Logger):
+    def info(self, msg):
+        if msg.startswith('[download] '):
+            super().info(msg)

--- a/yt_queue/utils/loggers.py
+++ b/yt_queue/utils/loggers.py
@@ -1,6 +1,20 @@
 import sys
 
-class StdLogger:
+class NoOpLogger:
+    def info(self, message):
+        pass
+    def warning(self, message):
+        pass
+    def error(self, message):
+        pass
+    def output(self, data):
+        pass
+
+class QuietLogger(NoOpLogger):
+    def output(self, data):
+        _stdout(data)
+
+class StdLogger(QuietLogger):
     def __init__(self, formatted_output=False):
         self.formatted_output = formatted_output
 
@@ -15,9 +29,6 @@ class StdLogger:
 
     def error(self, message):
         _stderr(message)
-
-    def output(self, data):
-        _stdout(data)
 
 def _stdout(message):
     print(message)

--- a/yt_queue/utils/loggers.py
+++ b/yt_queue/utils/loggers.py
@@ -1,0 +1,25 @@
+import sys
+
+class StdLogger:
+    def __init__(self, formatted_output=False):
+        self.formatted_output = formatted_output
+
+    def info(self, message):
+        if self.formatted_output:
+            _stderr(message)
+        else:
+            _stdout(message)
+
+    def warning(self, message):
+        _stderr(message)
+
+    def error(self, message):
+        _stderr(message)
+
+    def output(self, data):
+        _stdout(data)
+
+def _stdout(message):
+    print(message)
+def _stderr(message):
+    print(message, file=sys.stderr)


### PR DESCRIPTION
create a `StdLogger` class and move all `print` statements to this. create and use a default instance in cli functions. add `formatted_output` option, which outputs `info` messages to `stderr` (allowing `output` to be the only data writted to `stdout`)

add loggers for `yt_dlp` and use less-verbose logging when refreshing