### PR TITLE
setup: remove Python 3.7, add 3.12 to CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Less verbose output in CLI
 - Less verbose `yt_dlp` output
 
+### Removed
+
+- Python 3.7 support (minimum is now `3.8`)
+
 ## 0.1.1
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "CLI to keep track of videos in Youtube playlists"
 keywords = ["yt-dlp", "YouTube"]
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
drop `3.7` (already end-of-life, not used in CI), changing the minimum version to `3.8`

add `3.12` to CI