### PR TITLE
cli: use argparse to parse arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Api: `filter_videos` function to filter by rules given (currently 'status', 'custom' function)
+- Api: `cli.argument_parser` to parse `sys.argv` using `argparse`
 
 ### Fixed
 

--- a/yt_queue/__init__.py
+++ b/yt_queue/__init__.py
@@ -1,5 +1,6 @@
 import sys
 from . import file
+from .cli import argument_parser
 from .internal import mapper, yt_dlp_wrapper
 from .filters import filter_videos
 from .utils.loggers import StdLogger
@@ -19,21 +20,12 @@ def write(filename, playlist_data):
 
 _log = StdLogger()
 
-def _create():
-    info = sys.argv[2]
-    url = sys.argv[3]
-    create(info, url)
-
 def create(info, url, logger=_log):
     data = {
         'url': url,
     }
     write(info, data)
     logger.info(f'{info} created')
-
-def _refresh():
-    info = sys.argv[2]
-    refresh(info)
 
 def refresh(info, logger=_log):
     data = read(info)
@@ -46,10 +38,6 @@ def refresh(info, logger=_log):
 
     write(info, data)
 
-def _get_no_status():
-    info = sys.argv[2]
-    get_no_status(info)
-
 def get_no_status(info, logger=_log):
     _log.formatted_output = True
     data = read(info)
@@ -58,10 +46,6 @@ def get_no_status(info, logger=_log):
     logger.info(f'Found {len(found)} videos with no status in {info}')
     for video in found:
         logger.output(video['id'])
-
-def _get_status():
-    [info, status] = sys.argv[2:4]
-    get_status(info, status)
 
 def get_status(info, status, logger=_log):
     _log.formatted_output = True
@@ -72,10 +56,6 @@ def get_status(info, status, logger=_log):
     for video in found:
         logger.output(video['id'])
 
-def _set_status():
-    [info, video_id, new_status] = sys.argv[2:5]
-    set_status(info, video_id, new_status)
-
 def set_status(info, video_id, new_status):
     data = read(info)
 
@@ -83,10 +63,6 @@ def set_status(info, video_id, new_status):
     for video in found:
         video['status'] = new_status
     write(info, data)
-
-def _read_field():
-    [info, video_id, field] = sys.argv[2:5]
-    read_field(info, video_id, field)
 
 def read_field(info, video_id, field, logger=_log):
     _log.formatted_output = True
@@ -97,21 +73,24 @@ def read_field(info, video_id, field, logger=_log):
         logger.output(found[0][field])
 
 def cli():
-    if len(sys.argv) == 2 and sys.argv[1] == 'version':
+    parser = argument_parser()
+    args = parser.parse_args()
+
+    if args.sub_command == 'version':
         _log.output(_fullname)
-    elif len(sys.argv) == 4 and sys.argv[1] == 'create':
-        _create()
-    elif len(sys.argv) == 3 and sys.argv[1] == 'refresh':
-        _refresh()
-    elif len(sys.argv) == 3 and sys.argv[1] == 'get-no-status':
-        _get_no_status()
-    elif len(sys.argv) == 4 and sys.argv[1] == 'get-status':
-        _get_status()
-    elif len(sys.argv) == 5 and sys.argv[1] == 'set-status':
-        _set_status()
-    elif len(sys.argv) == 5 and sys.argv[1] == 'read-field':
-        _read_field()
+    elif args.sub_command == 'create':
+        create(args.file, args.url)
+    elif args.sub_command == 'refresh':
+        refresh(args.file)
+    elif args.sub_command == 'get-no-status':
+        get_no_status(args.file)
+    elif args.sub_command == 'get-status':
+        get_status(args.file, args.status)
+    elif args.sub_command == 'set-status':
+        set_status(args.file, args.video_id, args.status)
+    elif args.sub_command == 'read-field':
+        read_field(args.file, args.video_id, args.field_name)
     else:
         _log.info(_fullname)
-        _log.warning(f'unknown cli arguments {sys.argv}')
+        _log.warning(f'Cli argument parsing failed {sys.argv} {args}')
         sys.exit(1)

--- a/yt_queue/cli.py
+++ b/yt_queue/cli.py
@@ -1,0 +1,55 @@
+import argparse
+
+def argument_parser():
+    parser = argparse.ArgumentParser(
+        prog='yt-queue',
+        description="Keep track of videos in Youtube playlists")
+
+    subparsers = parser.add_subparsers(title="subcommands", dest='sub_command', required=True)
+
+    subparsers.add_parser('version', help="Show the current version and exit")
+
+    _add_create_sub_command(subparsers)
+    _add_refresh_sub_command(subparsers)
+    _add_get_no_status_sub_command(subparsers)
+    _add_get_status_sub_command(subparsers)
+    _add_set_status_sub_command(subparsers)
+    _add_read_field_sub_command(subparsers)
+
+    return parser
+
+def _add_create_sub_command(subparsers):
+    parser_create = subparsers.add_parser('create',
+        help="Create a new file to track a playlist")
+    parser_create.add_argument('file')
+    parser_create.add_argument('url')
+
+def _add_refresh_sub_command(subparsers):
+    parser_refresh = subparsers.add_parser('refresh',
+        help="Refresh the playlist, updating the videos in the given file")
+    parser_refresh.add_argument('file')
+
+def _add_get_no_status_sub_command(subparsers):
+    parser_get_no_statue = subparsers.add_parser('get-no-status',
+        help="List video ids that have no 'status' field")
+    parser_get_no_statue.add_argument('file')
+
+def _add_get_status_sub_command(subparsers):
+    parser_get_statue = subparsers.add_parser('get-status',
+        help="List video ids that have a specific 'status' field value")
+    parser_get_statue.add_argument('file')
+    parser_get_statue.add_argument('status')
+
+def _add_set_status_sub_command(subparsers):
+    parser_set_statue = subparsers.add_parser('set-status',
+        help="Set a video's 'status' field")
+    parser_set_statue.add_argument('file')
+    parser_set_statue.add_argument('video_id')
+    parser_set_statue.add_argument('status')
+
+def _add_read_field_sub_command(subparsers):
+    parser_read_field = subparsers.add_parser('read-field',
+        help="Read a field from a video")
+    parser_read_field.add_argument('file')
+    parser_read_field.add_argument('video_id')
+    parser_read_field.add_argument('field_name')


### PR DESCRIPTION
create `cli` module with `argument_parser` that builds a `argparse.ArgumentParser` with the current cli arguments

use this in the main `cli` function, checking the sub_commands and calling the existing sub command functions

remove previous helper sub command functions (`_create` etc) that parsed the cli arguments into variables before calling the sub command functions

in the future the sub parsers should use `set_defaults(func=...)` with private functions in the `cli` module to handle cli/api function mappings

resolves #12