### PR TITLE
dev: use while IFS loop to get files to lint

### DIFF
--- a/dev/lint.sh
+++ b/dev/lint.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-mapfile -t py < <(git ls-files '*.py')
-echo "py files:" "${py[@]}"
+while IFS= read -r file; do py+=("$file"); done < <(git ls-files '*.py')
+echo "${#py[@]} py files:" "${py[@]}"
 python "$(which pylint)" "${py[@]}"
 
-mapfile -t sh < <(git ls-files 'yt-queue' '*.sh')
-echo "sh files:" "${sh[@]}"
+while IFS= read -r file; do sh+=("$file"); done < <(git ls-files 'yt-queue' '*.sh')
+echo "${#sh[@]} sh files:" "${sh[@]}"
 shellcheck "${sh[@]}"


### PR DESCRIPTION
`mapfile` is not available on bash 3.2 (Mac), so use a while loop to build the array of files to lint

print the total number of files before the file list

from https://stackoverflow.com/a/41475317/1016377