### PR TITLE
Refresh: Add last refreshed timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Added
+
+- Last `refreshed` timestamp
+
 ## 0.3.1
 
 ### Fixed

--- a/tests/test_compatability.py
+++ b/tests/test_compatability.py
@@ -1,0 +1,15 @@
+import pytest
+import yt_queue
+
+class TestEmptyFile:
+    @pytest.fixture(name='data')
+    def open_simple_file(self, tmp_path):
+        file = tmp_path / 'info.json'
+        with open(file, 'w', encoding='utf-8') as f:
+            f.write('{ "url": "https://example.com/playlist/1" }')
+        return yt_queue.file.read(file)
+
+    def test_url_as_set(self, data):
+        assert data['url'] == "https://example.com/playlist/1"
+    def test_empty_videos(self, data):
+        assert len(data['videos']) == 0

--- a/tests/test_compatability.py
+++ b/tests/test_compatability.py
@@ -13,3 +13,5 @@ class TestEmptyFile:
         assert data['url'] == "https://example.com/playlist/1"
     def test_empty_videos(self, data):
         assert len(data['videos']) == 0
+    def test_0_last_refresh(self, data):
+        assert data['refreshed'] == 0

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -1,10 +1,16 @@
+import pytest
 import yt_queue
 from .mocks import mock_yt_dlp, response_extract_info, append_to_response
 
-def test_refresh_skips_none_videos(tmp_path, monkeypatch):
+@pytest.fixture(name='path_to_created_file')
+def create_simple_file(tmp_path):
     file = tmp_path / 'info.json'
     with open(file, 'w', encoding='utf-8') as f:
         f.write('{ "url": "https://example.com/playlist/1" }')
+    return file
+
+def test_refresh_skips_none_videos(path_to_created_file, monkeypatch):
+    file = path_to_created_file
 
     response = response_extract_info(video_count=3)
     append_to_response(response, None)

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -19,3 +19,12 @@ def test_refresh_skips_none_videos(path_to_created_file, monkeypatch):
     yt_queue.refresh(file)
     data = yt_queue.read(file)
     assert len(data['videos']) == 3
+
+def test_saves_timestamp(path_to_created_file, monkeypatch):
+    file = path_to_created_file
+
+    mock_yt_dlp(monkeypatch, extract_info=response_extract_info())
+
+    yt_queue.refresh(file)
+    data = yt_queue.read(file)
+    assert data['refreshed'] > 0

--- a/yt_queue/__init__.py
+++ b/yt_queue/__init__.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import datetime
 from . import file
 from .cli import argument_parser
 from .internal import mapper, yt_dlp_wrapper
@@ -36,6 +37,7 @@ def refresh(info, logger=_log):
     for entry in yt_info['entries']:
         mapper.map_and_merge(entry, data['videos'])
 
+    data['refreshed'] = datetime.utcnow().timestamp()
     write(info, data)
 
 def get_no_status(info, logger=_log):

--- a/yt_queue/file.py
+++ b/yt_queue/file.py
@@ -3,6 +3,8 @@ import json
 def read(filename):
     with open(filename, 'r', encoding='utf-8') as file:
         playlist_data = json.load(file)
+    if not 'refreshed' in playlist_data:
+        playlist_data['refreshed'] = 0
     if not 'videos' in playlist_data:
         playlist_data['videos'] = []
     return playlist_data


### PR DESCRIPTION
add a test for opening basic files with comparability (setting all required fields)

save the current utc timestamp after the playlilst is refreshed. In the future this field will be used to conditionally refresh