### PR TITLE
add info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- CLI: `info` command to show info and statistics
 - Last `refreshed` timestamp
 
 ## 0.3.1

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -63,6 +63,12 @@ test_can_refresh_info() {
   ok
 }
 
+test_can_show_info() {
+  $cli info "$info" >$log 2>&1
+  # not fully parsable
+  ok
+}
+
 test_refresh_only_adds_new_item_does_not_remove_old_or_readd_existing() {
   cp "$example_info" "$info"
 
@@ -117,6 +123,7 @@ test_cli_is_executable
 test_cli_fails_for_invalid_params
 test_can_create_info
 test_can_refresh_info
+test_can_show_info
 test_refresh_only_adds_new_item_does_not_remove_old_or_readd_existing
 test_can_manage_item_status
 test_can_read_field_in_video

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -29,6 +29,19 @@ def test_can_refresh(tmp_path, monkeypatch):
     data = yt_queue.read(file)
     assert len(data['videos']) == 3
 
+def test_can_output_info(file_with_some_data, capsys):
+    file = file_with_some_data
+
+    yt_queue.show_info(file)
+    captured = capsys.readouterr()
+    # the output is not _fully_ parsable, but contains:
+    assert captured.out.find("https://example.com/playlist/1") != -1
+    assert captured.out.find("Last refreshed: ") != -1
+    assert captured.out.find("3 videos") != -1
+    assert captured.out.find("1 distinct status:") != -1
+    assert captured.out.find("2 with test") != -1
+    assert captured.out.find("1 with no status") != -1
+
 def test_can_filter_by_status(file_with_some_data, capsys):
     file = file_with_some_data
 

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -1,7 +1,15 @@
 from pathlib import Path
 import json
+import pytest
 import yt_queue
 from .mocks import mock_yt_dlp, response_extract_info, data_dict
+
+@pytest.fixture(name='file_with_some_data')
+def create_info_file(tmp_path):
+    file = tmp_path / 'info.json'
+    with open(file, 'w', encoding='utf-8') as f:
+        json.dump(data_dict(), f)
+    return file
 
 def test_can_create(tmp_path):
     info = Path(tmp_path, 'info.json')
@@ -21,10 +29,8 @@ def test_can_refresh(tmp_path, monkeypatch):
     data = yt_queue.read(file)
     assert len(data['videos']) == 3
 
-def test_can_filter_by_status(tmp_path, capsys):
-    file = tmp_path / 'info.json'
-    with open(file, 'w', encoding='utf-8') as f:
-        json.dump(data_dict(), f)
+def test_can_filter_by_status(file_with_some_data, capsys):
+    file = file_with_some_data
 
     yt_queue.get_no_status(file)
     captured = capsys.readouterr()
@@ -34,10 +40,8 @@ def test_can_filter_by_status(tmp_path, capsys):
     captured = capsys.readouterr()
     assert captured.out == "idB\nidC\n"
 
-def test_can_set_status(tmp_path, capsys):
-    file = tmp_path / 'info.json'
-    with open(file, 'w', encoding='utf-8') as f:
-        json.dump(data_dict(), f)
+def test_can_set_status(file_with_some_data, capsys):
+    file = file_with_some_data
 
     yt_queue.set_status(file, "idB", "new-status")
     capsys.readouterr()
@@ -49,10 +53,8 @@ def test_can_set_status(tmp_path, capsys):
     captured = capsys.readouterr()
     assert captured.out == "idC\n"
 
-def test_can_read_field_of_video(tmp_path, capsys):
-    file = tmp_path / 'info.json'
-    with open(file, 'w', encoding='utf-8') as f:
-        json.dump(data_dict(), f)
+def test_can_read_field_of_video(file_with_some_data, capsys):
+    file = file_with_some_data
 
     yt_queue.read_field(file, "idA", "url")
     captured = capsys.readouterr()

--- a/yt_queue/__init__.py
+++ b/yt_queue/__init__.py
@@ -63,7 +63,7 @@ def refresh(info, logger=_log):
     for entry in yt_info['entries']:
         mapper.map_and_merge(entry, data['videos'])
 
-    data['refreshed'] = datetime.utcnow().timestamp()
+    data['refreshed'] = datetime.now().timestamp()
     write(info, data)
 
 def get_no_status(info, logger=_log):

--- a/yt_queue/__init__.py
+++ b/yt_queue/__init__.py
@@ -28,6 +28,32 @@ def create(info, url, logger=_log):
     write(info, data)
     logger.info(f'{info} created')
 
+def show_info(info, logger=_log):
+    data = read(info)
+    logger.info(f"URL: {data['url']}")
+
+    local_time_last_refresh = datetime.fromtimestamp(data['refreshed']).astimezone().isoformat()
+    logger.output(f"Last refreshed: {local_time_last_refresh}")
+
+    logger.output(f"{len(data['videos'])} videos")
+
+    no_status = 0
+    status_counts = {}
+    for video in data['videos']:
+        if 'status' in video:
+            status = video['status']
+            if status in status_counts:
+                status_counts[status] += 1
+            else:
+                status_counts[status] = 1
+        else:
+            no_status += 1
+
+    logger.output(f"{len(status_counts.keys())} distinct status:")
+    for status, count in status_counts.items():
+        logger.output(f"{count} with {status}")
+    logger.output(f"{no_status} with no status")
+
 def refresh(info, logger=_log):
     data = read(info)
     url = data['url']
@@ -82,6 +108,8 @@ def cli():
         _log.output(_fullname)
     elif args.sub_command == 'create':
         create(args.file, args.url)
+    elif args.sub_command == 'info':
+        show_info(args.file)
     elif args.sub_command == 'refresh':
         refresh(args.file)
     elif args.sub_command == 'get-no-status':

--- a/yt_queue/cli.py
+++ b/yt_queue/cli.py
@@ -11,6 +11,7 @@ def argument_parser():
 
     _add_create_sub_command(subparsers)
     _add_refresh_sub_command(subparsers)
+    _add_info_sub_command(subparsers)
     _add_get_no_status_sub_command(subparsers)
     _add_get_status_sub_command(subparsers)
     _add_set_status_sub_command(subparsers)
@@ -28,6 +29,11 @@ def _add_refresh_sub_command(subparsers):
     parser_refresh = subparsers.add_parser('refresh',
         help="Refresh the playlist, updating the videos in the given file")
     parser_refresh.add_argument('file')
+
+def _add_info_sub_command(subparsers):
+    parser_info = subparsers.add_parser('info',
+        help="Show info and statistics about the file and videos")
+    parser_info.add_argument('file')
 
 def _add_get_no_status_sub_command(subparsers):
     parser_get_no_statue = subparsers.add_parser('get-no-status',


### PR DESCRIPTION
show basic details about the fille (url, last refreshed) and the
statuses set for the videos

the output is somewhat parsable, but might not be as a whole

fix: dont use `utcnow`, use `now().timestamp()`