### PR TITLE
filter: add filter cli command, with optional flags for status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## unreleased
+
+### Deprecated
+
+- CLI: `get-no-status`: use `filter --no-status` instead
+- CLI: `get-status`: use `filter ... --status=...` instead
+- api: `get_no_status`: use `list_filtered_ids(..., {'only_no_status': True})` instead
+- api: `get_status`: use `list_filtered_ids(..., {'status': ...})` instead
+
 ## 0.5.0
 
 ### Added

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -89,17 +89,17 @@ test_can_manage_item_status() {
   cp "$example_info" "$info"
   std_out=tests/out.log
 
-  $cli get-no-status "$info" >$std_out 2>$log
+  $cli filter --no-status "$info" >$std_out 2>$log
   assert "$(cat $std_out)" \
     "invalid-id
 $expected_video_id"
 
   $cli set-status "$info" "invalid-id" "test-status-123"
 
-  $cli get-no-status "$info" >$std_out 2>$log
+  $cli filter --no-status "$info" >$std_out 2>$log
   assert "$(cat $std_out)" "$expected_video_id"
 
-  $cli get-status "$info" test-status-123 >$std_out 2>$log
+  $cli filter "$info" --status=test-status-123 >$std_out 2>$log
   assert "$(cat $std_out)" "invalid-id"
 
   ok

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -45,11 +45,11 @@ def test_can_output_info(file_with_some_data, capsys):
 def test_can_filter_by_status(file_with_some_data, capsys):
     file = file_with_some_data
 
-    yt_queue.get_no_status(file)
+    yt_queue.list_filtered_ids(file, {'only_no_status': True})
     captured = capsys.readouterr()
     assert captured.out == "idA\n"
 
-    yt_queue.get_status(file, "test")
+    yt_queue.list_filtered_ids(file, {'status': "test"})
     captured = capsys.readouterr()
     assert captured.out == "idB\nidC\n"
 

--- a/yt_queue/__init__.py
+++ b/yt_queue/__init__.py
@@ -77,23 +77,31 @@ def refresh(info, logger=_log, only_if_older=None):
     write(info, data)
     return data['refreshed']
 
-def get_no_status(info, logger=_log):
+def list_filtered_ids(info, options, logger=_log):
     _log.formatted_output = True
     data = read(info)
+    found = data['videos']
 
-    found = filter_videos(data, { 'status': None })
-    logger.info(f'Found {len(found)} videos with no status in {info}')
+    only_no_status = options.get('only_no_status')
+    status = options.get('status')
+
+    if only_no_status:
+        found = filter_videos({ 'videos': found }, { 'status': None })
+        logger.info(f'Found {len(found)} videos with no status')
+    if status is not None:
+        found = filter_videos({ 'videos': found }, { 'status': status })
+        logger.info(f'Found {len(found)} videos with status {status}')
+
     for video in found:
         logger.output(video['id'])
+
+def get_no_status(info, logger=_log):
+    logger.warning('get-no-status is deprecated, use filter --no-status')
+    list_filtered_ids(info, {'only_no_status': True})
 
 def get_status(info, status, logger=_log):
-    _log.formatted_output = True
-    data = read(info)
-
-    found = filter_videos(data, { 'status': status })
-    logger.info(f'Found {len(found)} videos with status {status} in {info}')
-    for video in found:
-        logger.output(video['id'])
+    logger.warning(f'get-status is deprecated, use filter --status {status}')
+    list_filtered_ids(info, {'status': status})
 
 def set_status(info, video_id, new_status):
     data = read(info)
@@ -123,6 +131,11 @@ def cli():
         show_info(args.file)
     elif args.sub_command == 'refresh':
         refresh(args.file, only_if_older=args.only_if_older)
+    elif args.sub_command == 'filter':
+        list_filtered_ids(args.file, {
+            'only_no_status': args.no_status,
+            'status': args.status,
+        })
     elif args.sub_command == 'get-no-status':
         get_no_status(args.file)
     elif args.sub_command == 'get-status':

--- a/yt_queue/cli.py
+++ b/yt_queue/cli.py
@@ -14,6 +14,7 @@ def argument_parser():
     _add_info_sub_command(subparsers)
     _add_get_no_status_sub_command(subparsers)
     _add_get_status_sub_command(subparsers)
+    _add_filter_sub_command(subparsers)
     _add_set_status_sub_command(subparsers)
     _add_read_field_sub_command(subparsers)
 
@@ -40,14 +41,25 @@ def _add_info_sub_command(subparsers):
 
 def _add_get_no_status_sub_command(subparsers):
     parser_get_no_statue = subparsers.add_parser('get-no-status',
-        help="List video ids that have no 'status' field")
+        help="List video ids that have no 'status' field. " +
+             "Use filter --no-status instead")
     parser_get_no_statue.add_argument('file')
 
 def _add_get_status_sub_command(subparsers):
     parser_get_statue = subparsers.add_parser('get-status',
-        help="List video ids that have a specific 'status' field value")
+        help="List video ids that have a specific 'status' field value. " +
+             "Use filter --status=<status> instead")
     parser_get_statue.add_argument('file')
     parser_get_statue.add_argument('status')
+
+def _add_filter_sub_command(subparsers):
+    parser_filter = subparsers.add_parser('filter',
+        help="List video ids that matches the given filter arguments")
+    parser_filter.add_argument('file')
+
+    status = parser_filter.add_mutually_exclusive_group()
+    status.add_argument('--status')
+    status.add_argument('--no-status', action='store_true')
 
 def _add_set_status_sub_command(subparsers):
     parser_set_statue = subparsers.add_parser('set-status',


### PR DESCRIPTION
add `filter` command with `--no-status` and `--status=...` arguments

call a new `list_filtered_ids` function for cli. deprecate `get_no_status` and `get_status` functions, changing them to use `list_filtered_ids`