### PR TITLE
simplify filter cli function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - CLI: `get-no-status`: use `filter --no-status` instead
 - CLI: `get-status`: use `filter ... --status=...` instead
-- api: `get_no_status`: use `list_filtered_ids(..., {'only_no_status': True})` instead
+- api: `get_no_status`: use `list_filtered_ids(..., {'status': None})` instead
 - api: `get_status`: use `list_filtered_ids(..., {'status': ...})` instead
 
 ## 0.5.0

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -102,6 +102,12 @@ $expected_video_id"
   $cli filter "$info" --status=test-status-123 >$std_out 2>$log
   assert "$(cat $std_out)" "invalid-id"
 
+  # not filtering anything returns everything
+  $cli filter "$info" >$std_out 2>$log
+  assert "$(cat $std_out)" \
+    "invalid-id
+$expected_video_id"
+
   # deprecated
   $cli get-no-status "$info" >$std_out 2>$log
   assert "$(cat $std_out)" "$expected_video_id"

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -102,6 +102,12 @@ $expected_video_id"
   $cli filter "$info" --status=test-status-123 >$std_out 2>$log
   assert "$(cat $std_out)" "invalid-id"
 
+  # deprecated
+  $cli get-no-status "$info" >$std_out 2>$log
+  assert "$(cat $std_out)" "$expected_video_id"
+  $cli get-status "$info" test-status-123 >$std_out 2>$log
+  assert "$(cat $std_out)" "invalid-id"
+
   ok
 }
 

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -53,6 +53,14 @@ def test_can_filter_by_status(file_with_some_data, capsys):
     captured = capsys.readouterr()
     assert captured.out == "idB\nidC\n"
 
+    # deprecated still works
+    yt_queue.get_no_status(file)
+    captured = capsys.readouterr()
+    assert captured.out == "idA\n"
+    yt_queue.get_status(file, "test")
+    captured = capsys.readouterr()
+    assert captured.out == "idB\nidC\n"
+
 def test_can_set_status(file_with_some_data, capsys):
     file = file_with_some_data
 

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -45,7 +45,7 @@ def test_can_output_info(file_with_some_data, capsys):
 def test_can_filter_by_status(file_with_some_data, capsys):
     file = file_with_some_data
 
-    yt_queue.list_filtered_ids(file, {'only_no_status': True})
+    yt_queue.list_filtered_ids(file, {'status': None})
     captured = capsys.readouterr()
     assert captured.out == "idA\n"
 

--- a/tests/test_cli_functions.py
+++ b/tests/test_cli_functions.py
@@ -61,6 +61,13 @@ def test_can_filter_by_status(file_with_some_data, capsys):
     captured = capsys.readouterr()
     assert captured.out == "idB\nidC\n"
 
+def test_can_filter_nothing_filtered_by_default(file_with_some_data, capsys):
+    file = file_with_some_data
+
+    yt_queue.list_filtered_ids(file, {})
+    captured = capsys.readouterr()
+    assert captured.out == "idA\nidB\nidC\n"
+
 def test_can_set_status(file_with_some_data, capsys):
     file = file_with_some_data
 

--- a/yt_queue/__init__.py
+++ b/yt_queue/__init__.py
@@ -119,6 +119,12 @@ def read_field(info, video_id, field, logger=_log):
     if any(found) and field in found[0]:
         logger.output(found[0][field])
 
+def _filter_options_from_arg_parse(args):
+    return {
+        'only_no_status': args.no_status,
+        'status': args.status,
+    }
+
 def cli():
     parser = argument_parser()
     args = parser.parse_args()
@@ -132,10 +138,7 @@ def cli():
     elif args.sub_command == 'refresh':
         refresh(args.file, only_if_older=args.only_if_older)
     elif args.sub_command == 'filter':
-        list_filtered_ids(args.file, {
-            'only_no_status': args.no_status,
-            'status': args.status,
-        })
+        list_filtered_ids(args.file, _filter_options_from_arg_parse(args))
     elif args.sub_command == 'get-no-status':
         get_no_status(args.file)
     elif args.sub_command == 'get-status':

--- a/yt_queue/__init__.py
+++ b/yt_queue/__init__.py
@@ -80,24 +80,15 @@ def refresh(info, logger=_log, only_if_older=None):
 def list_filtered_ids(info, options, logger=_log):
     _log.formatted_output = True
     data = read(info)
-    found = data['videos']
 
-    only_no_status = options.get('only_no_status')
-    status = options.get('status')
-
-    if only_no_status:
-        found = filter_videos({ 'videos': found }, { 'status': None })
-        logger.info(f'Found {len(found)} videos with no status')
-    if status is not None:
-        found = filter_videos({ 'videos': found }, { 'status': status })
-        logger.info(f'Found {len(found)} videos with status {status}')
-
+    found = filter_videos(data, options)
+    logger.info(f'Found {len(found)} matching videos')
     for video in found:
         logger.output(video['id'])
 
 def get_no_status(info, logger=_log):
     logger.warning('get-no-status is deprecated, use filter --no-status')
-    list_filtered_ids(info, {'only_no_status': True})
+    list_filtered_ids(info, {'status': None})
 
 def get_status(info, status, logger=_log):
     logger.warning(f'get-status is deprecated, use filter --status {status}')
@@ -120,10 +111,13 @@ def read_field(info, video_id, field, logger=_log):
         logger.output(found[0][field])
 
 def _filter_options_from_arg_parse(args):
-    return {
-        'only_no_status': args.no_status,
-        'status': args.status,
-    }
+    options = {}
+    if args.status:
+        options['status'] = args.status
+    elif args.no_status:
+        options['status'] = None
+
+    return options
 
 def cli():
     parser = argument_parser()


### PR DESCRIPTION
change the options passed into `list_filtered_ids` to use `status: None`
when getting videos with no status.  change `only_no_status: True` references to
`status: None`

use the non-existance of the `status` key to indicate to not filter on
status at all

this allows `list_filtered_ids` to call `filter_videos` with the options
directly, without doint it's own mapping from the options

change `_filter_options_from_arg_parse` to do this mapping