### PR TITLE
tests: add python tests for cli parsing

### DIFF
--- a/tests/cli/test_cli_arguments.py
+++ b/tests/cli/test_cli_arguments.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import json
+import pytest
+from yt_queue import cli, VERSION
+from ..mocks import data_dict
+
+@pytest.fixture(name='file_with_some_data')
+def create_info_file(tmp_path):
+    file = Path(tmp_path, 'info.json')
+    with open(file, 'w', encoding='utf-8') as f:
+        json.dump(data_dict(), f)
+    return file
+
+def test_version(capsys):
+    cli("version".split())
+    captured = capsys.readouterr()
+    assert captured.out.find(f"yt-queue {VERSION}") != -1
+
+def test_create(tmp_path):
+    info = Path(tmp_path, 'info.json')
+
+    assert not info.exists()
+    cli(f"create {info} https://example.com/playlist/1".split())
+    assert info.is_file()
+
+def test_info(file_with_some_data, capsys):
+    cli(f"info {file_with_some_data}".split())
+
+    captured = capsys.readouterr()
+    # see `test_can_output_info` for more detailed output
+    assert captured.out.find("1 distinct status:") != -1
+
+def test_read_field(file_with_some_data, capsys):
+    cli(f"read-field {file_with_some_data} idA url".split())
+    captured = capsys.readouterr()
+    assert captured.out == "https://example.com/videos/a\n"
+
+def test_set_status(file_with_some_data, capsys):
+    def assert_on_status(expected):
+        cli(f"filter {file_with_some_data} --status new-status".split())
+        captured = capsys.readouterr()
+        if expected is None:
+            assert captured.out == ""
+        else:
+            assert captured.out == f"{expected}\n"
+
+    assert_on_status(expected = None)
+    cli(f"set-status {file_with_some_data} idB new-status".split())
+    assert_on_status("idB")

--- a/tests/cli/test_filter.py
+++ b/tests/cli/test_filter.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import json
+import pytest
+from yt_queue import cli
+from ..mocks import data_dict
+
+@pytest.fixture(name='file_with_some_data')
+def create_info_file(tmp_path):
+    file = Path(tmp_path, 'info.json')
+    with open(file, 'w', encoding='utf-8') as f:
+        json.dump(data_dict(), f)
+    return file
+
+def test_filter_without_args_returns_all(file_with_some_data, capsys):
+    cli(f"filter {file_with_some_data}".split())
+    captured = capsys.readouterr()
+    assert captured.out == "idA\nidB\nidC\n"
+
+def test_filter_status(file_with_some_data, capsys):
+    cli(f"filter {file_with_some_data} --status test".split())
+    captured = capsys.readouterr()
+    assert captured.out == "idB\nidC\n"
+
+def test_filter_no_status(file_with_some_data, capsys):
+    cli(f"filter {file_with_some_data} --no-status".split())
+    captured = capsys.readouterr()
+    assert captured.out == "idA\n"
+
+def test_filter_min_duration(file_with_some_data, capsys):
+    cli(f"filter {file_with_some_data} --min-duration 60".split())
+    captured = capsys.readouterr()
+    assert captured.out.find("idB") == -1
+
+def test_filter_max_duration(file_with_some_data, capsys):
+    cli(f"filter {file_with_some_data} --max-duration 60".split())
+    captured = capsys.readouterr()
+    assert captured.out.find("idB") != -1
+
+def test_filter_title(file_with_some_data, capsys):
+    regex = '[BC]$'
+    cli(f"filter {file_with_some_data} --title {regex}".split())
+    captured = capsys.readouterr()
+    assert captured.out == "idB\nidC\n"

--- a/tests/cli/test_refresh.py
+++ b/tests/cli/test_refresh.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from datetime import datetime, timedelta
+from yt_queue import cli, read
+from ..mocks import mock_yt_dlp, response_extract_info
+
+def test_refresh(tmp_path, monkeypatch):
+    file = Path(tmp_path, 'info.json')
+    with open(file, 'w', encoding='utf-8') as f:
+        f.write('{ "url": "https://example.com/playlist/1" }')
+
+    mock_yt_dlp(monkeypatch, extract_info=response_extract_info(video_count=3))
+
+    cli(f"refresh {file}".split())
+    data = read(file)
+    assert len(data['videos']) == 3
+
+def test_refresh_only_if_older(tmp_path, monkeypatch):
+    file = Path(tmp_path, 'info.json')
+    ten_minutes_ago = datetime.now().timestamp() - timedelta(minutes=10).total_seconds()
+
+    with open(file, 'w', encoding='utf-8') as f:
+        f.write('{')
+        f.write('"url": "https://example.com/playlist/1",')
+        f.write(f'"refreshed": {ten_minutes_ago}')
+        f.write('}')
+
+    mock_yt_dlp(monkeypatch, extract_info=response_extract_info(video_count=3))
+
+    cli(f"refresh {file} --only-if-older 15mins".split())
+    data = read(file)
+    assert len(data['videos']) == 0
+
+    cli(f"refresh {file} --only-if-older 5mins".split())
+    data = read(file)
+    assert len(data['videos']) == 3

--- a/yt_queue/__init__.py
+++ b/yt_queue/__init__.py
@@ -125,9 +125,9 @@ def _filter_options_from_arg_parse(args):
 
     return options
 
-def cli():
+def cli(argv=sys.argv[1:]):
     parser = argument_parser()
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.sub_command == 'version':
         _log.output(_fullname)


### PR DESCRIPTION
add tests in python for cli arguments parsing and results. this is similar to the cli function tests, but the input is a cli string

fixes #25