### PR TITLE
cli filter: fix mutual exclution check

### DIFF
--- a/tests/cli/test_filter.py
+++ b/tests/cli/test_filter.py
@@ -41,3 +41,20 @@ def test_filter_title(file_with_some_data, capsys):
     cli(f"filter {file_with_some_data} --title {regex}".split())
     captured = capsys.readouterr()
     assert captured.out == "idB\nidC\n"
+
+def test_filter_mutex_status_no_status(file_with_some_data):
+    with pytest.raises(SystemExit):
+        cli(f"filter {file_with_some_data} --no-status --status test".split())
+
+def test_filter_all(file_with_some_data, capsys):
+    regex = '[BC]$'
+    cli([
+        "filter",
+        f"{file_with_some_data}",
+        "--title",          f"{regex}",
+        "--min-duration",   "60",
+        "--max-duration",   "1800",
+        "--status",         "test",
+    ])
+    captured = capsys.readouterr()
+    assert captured.out == "idC\n"

--- a/yt_queue/cli.py
+++ b/yt_queue/cli.py
@@ -61,12 +61,11 @@ def _add_filter_sub_command(subparsers):
     status.add_argument('--status')
     status.add_argument('--no-status', action='store_true')
 
-    # should add parsing tests for this in #25
-    status.add_argument('--min-duration', type=int,
+    parser_filter.add_argument('--min-duration', type=int,
                         help="Return only videos with duration >= MIN_DURATION")
-    status.add_argument('--max-duration', type=int,
+    parser_filter.add_argument('--max-duration', type=int,
                         help="Return only videos with duration <= MAX_DURATION")
-    status.add_argument('--title',
+    parser_filter.add_argument('--title',
                         help="Return only videos with a title matching the regular expression")
 
 def _add_set_status_sub_command(subparsers):


### PR DESCRIPTION
only `--status` and `--no-status` should be mutually exclusive, the other filter options can be used together