### PR TITLE
docs cleanup, more testsing of examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 *.egg-info
 tests/info.json
 readme-example.ytq.json
+readme-example.sh
+example.ytq.json

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ CLI to keep track of videos in Youtube playlists
 
 ## cli
 
-tl;dr:
+See `yt-queue -h` and `yt-queue <subcommand> -h` for details.
+
+Examples:
 
 ```sh
 yt-queue create <name.ytq.json> <url>
@@ -23,13 +25,11 @@ yt-queue filter --min-duration 3 <name.ytq.json>
 yt-queue filter --max-duration 11 <name.ytq.json>
 ```
 
-See `yt-queue -h` or `yt-queue <subcommand> -h` for details.
-
 ### output
 
 Most cli subcommands' output (`stdout`) is parsable. `stderr` is used for logging:
 
-- `get-no-status` and `get-status` returns the video ids, 1 per line
+- `filter` returns the matching video ids, 1 per line
 - `read-field` returns the value of the field for the given video id
 
 Other subcommands output should not be parsed - they contain either progress or verbose logging (including

--- a/README.md
+++ b/README.md
@@ -8,21 +8,27 @@ See `yt-queue -h` and `yt-queue <subcommand> -h` for details.
 Examples:
 
 ```sh
-yt-queue create <name.ytq.json> <url>
-yt-queue refresh <name.ytq.json> --only-if-older=1day
-yt-queue filter --no-status <name.ytq.json>
-yt-queue read-field <name.ytq.json> <video-id> url
-yt-queue read-field <name.ytq.json> <video-id> title
-yt-queue set-status <name.ytq.json> <video-id> <status>
-yt-queue filter --status=<status> <name.ytq.json>
-```
+# create a new file
+yt-queue create example.ytq.json "https://www.youtube.com/playlist?list=PL0pg4HdU1lNMtRzycn3wbKyfQO5vQZja9"
 
-more filter options:
+# refresh a file, only if it wasnt recently updated
+yt-queue refresh example.ytq.json --only-if-older=1day
 
-```sh
-yt-queue filter --title "test video" <name.ytq.json>
-yt-queue filter --min-duration 3 <name.ytq.json>
-yt-queue filter --max-duration 11 <name.ytq.json>
+# get the "new" items
+yt-queue filter --no-status example.ytq.json
+
+# read the values of a video from the file
+yt-queue read-field example.ytq.json "BaW_jenozKc" url
+yt-queue read-field example.ytq.json "BaW_jenozKc" title
+
+# set the status
+yt-queue set-status example.ytq.json "BaW_jenozKc" some-text-status
+yt-queue filter --status=some-text-status example.ytq.json
+
+# more filter options
+yt-queue filter --title "test video" example.ytq.json
+yt-queue filter --min-duration 3 example.ytq.json
+yt-queue filter --max-duration 11 example.ytq.json
 ```
 
 ### output

--- a/tests/doc.sh
+++ b/tests/doc.sh
@@ -17,8 +17,12 @@ else
   export PATH=".:$PATH"
 fi
 
+echo "Testing that example works as expected"
+rm -f readme-example.ytq.json
+
 # create a new file
 yt-queue create readme-example.ytq.json "$example_playlist"
+test -f readme-example.ytq.json
 
 # refresh a file, only if it wasnt recently updated
 yt-queue refresh readme-example.ytq.json --only-if-older=1day
@@ -28,8 +32,10 @@ yt-queue filter --no-status readme-example.ytq.json | \
   grep "$example_video_id"
 
 # read the values of a video from the file
-yt-queue read-field readme-example.ytq.json "$example_video_id" url
-yt-queue read-field readme-example.ytq.json "$example_video_id" title
+yt-queue read-field readme-example.ytq.json "$example_video_id" url | \
+  grep -E "youtube.com/.*$example_video_id"
+yt-queue read-field readme-example.ytq.json "$example_video_id" title | \
+  grep -E "test video"
 
 # set the status
 yt-queue set-status readme-example.ytq.json "$example_video_id" some-text-status

--- a/tests/doc.sh
+++ b/tests/doc.sh
@@ -49,3 +49,16 @@ yt-queue filter --min-duration 3 readme-example.ytq.json | \
   grep "$example_video_id"
 yt-queue filter --max-duration 11 readme-example.ytq.json | \
   grep "$example_video_id"
+echo ""
+
+echo "Testing markdown example"
+$0 doc > readme-example.sh
+bash -xe readme-example.sh
+echo ""
+
+echo "Markdown example:"
+echo '```sh'
+cat readme-example.sh
+echo '```'
+
+rm readme-example.sh

--- a/tests/doc.sh
+++ b/tests/doc.sh
@@ -5,12 +5,13 @@ example_playlist="https://www.youtube.com/playlist?list=PL0pg4HdU1lNMtRzycn3wbKy
 example_video_id=BaW_jenozKc
 
 if [ "$1" = "doc" ] ; then
-  grep "^yt-queue" < "$0" | \
-    sed 's#readme-example.ytq.json#<name.ytq.json>#g' | \
-    sed 's#".example_playlist"#<url>#g' | \
-    sed 's#".example_video_id"#<video-id>#g' | \
-    sed 's#watched#<status>#g' | \
-    sed 's# |.*##g'
+  grep -E "^(yt-queue|# )" < "$0" | \
+    sed 's#readme-example.ytq.json#example.ytq.json#g' | \
+    sed 's#".example_playlist"#"'"$example_playlist"'"#g' | \
+    sed 's#".example_video_id"#"'"$example_video_id"'"#g' | \
+    sed 's# |.*##g' | \
+    sed 's,^# ,\n# ,g' | \
+    tail --lines +2
   exit 0
 else
   export PATH=".:$PATH"
@@ -31,8 +32,8 @@ yt-queue read-field readme-example.ytq.json "$example_video_id" url
 yt-queue read-field readme-example.ytq.json "$example_video_id" title
 
 # set the status
-yt-queue set-status readme-example.ytq.json "$example_video_id" watched
-yt-queue filter --status=watched readme-example.ytq.json | \
+yt-queue set-status readme-example.ytq.json "$example_video_id" some-text-status
+yt-queue filter --status=some-text-status readme-example.ytq.json | \
   grep "$example_video_id"
 
 # more filter options


### PR DESCRIPTION
move cli help up, use replace get-no-status with filter command

change examples to be runnable, without templates:; replace placeholder `<...>` items with valid example values. add comments from shell script in README

add more tests for the example commands: check that the file is created (remove first), find expected output in `read-field` commands

run the examples script one, with assertions on the results of the `yt-queue` command

then generate the example commands for markdown, and run those
generated commands (as is, without assertions)

finally output the example commands with backticks